### PR TITLE
Disambiguating references to 'file'.

### DIFF
--- a/batteries/Li2o2_Data_Processing.py
+++ b/batteries/Li2o2_Data_Processing.py
@@ -39,8 +39,8 @@ for i in np.arange(n_cycles):
 fontname = 'Times New Roman'
 
 "===================== PLOTTING FUNCTION ============================="
-def graph(file):
-    Data = pd.read_table(file, sep='deliminator', engine='python', header=None)
+def graph(filename):
+    Data = pd.read_table(filename, sep='deliminator', engine='python', header=None)
     Data.dropna(inplace = True)
     Data = Data[0].str.split("\t", expand = True)
 
@@ -54,7 +54,7 @@ def graph(file):
     Data[3] = Data[3].astype(float) # Current [A]
     
     Data['capacity'] = Data[1] * abs(Data[3])/carb_m*1000/3600 #convert to mAh/g
-    title = file.split("_cycle")
+    title = filename.split("_cycle")
     # Read out the cycle number:
     title2 = title[1].split(".")
     n_cycle = int(title2[0]) # cycle number


### PR DESCRIPTION
The `Li2O2_plotting.py` script had several references to a `file` both in and out of the `graph` function.  This renames `file` inside of `graph` to `filename` so as to disambiguate the references.